### PR TITLE
Add support for user domains (bug 1471882)

### DIFF
--- a/monascaclient/common/http.py
+++ b/monascaclient/common/http.py
@@ -62,6 +62,8 @@ class HTTPClient(object):
         self.auth_token = kwargs.get('token')
         self.username = kwargs.get('username')
         self.password = kwargs.get('password')
+        self.user_domain_id = kwargs.get('user_domain_id')
+        self.user_domain_name = kwargs.get('user_domain_name')
         self.region_name = kwargs.get('region_name')
         self.include_pass = kwargs.get('include_pass')
         self.endpoint_url = endpoint
@@ -99,6 +101,8 @@ class HTTPClient(object):
         ks_args = {
             'username': self.username,
             'password': self.password,
+            'user_domain_id': self.user_domain_id,
+	    'user_domain_name': self.user_domain_name,
             'token': '',
             'auth_url': self.auth_url,
             'service_type': self.service_type,
@@ -255,6 +259,7 @@ class HTTPClient(object):
         return resp
 
     def credentials_headers(self):
+        LOG.warning('Using Monasca-API w/o Keystone')
         creds = {}
         if self.username:
             creds['X-Auth-User'] = self.username

--- a/monascaclient/ksclient.py
+++ b/monascaclient/ksclient.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2014 Hewlett-Packard Development Company, L.P.
+# Copyright (c) 2014 Hewlett-Packard Development Company, L.P.i
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,10 +18,13 @@ Wrapper around python keystone client to assist in getting a properly scoped tok
 endpoint for Monasca.
 """
 
+import logging
+
 from keystoneclient.v3 import client
 
 from monascaclient import exc
 
+log = logging.getLogger(__name__)
 
 class KSClient(object):
     def __init__(self, **kwargs):
@@ -29,7 +32,9 @@ class KSClient(object):
 
         :param username: name of user
         :param password: user's password
-        :param project_id: unique identifier of project
+        :param user_domain_id: unique identifier of domain username resides in (optional)
+	:param user_domain_name: name of domain for username
+	:param project_id: unique identifier of project
         :param project_name: name of project
         :param domain_name: name of domain project is in
         :param domain_id: id of domain project is in
@@ -45,9 +50,9 @@ class KSClient(object):
             kc_args['project_id'] = kwargs.get('project_id')
         elif kwargs.get('project_name'):
             kc_args['project_name'] = kwargs.get('project_name')
-            if kwargs.get('domain_name'):
+            if kwargs.get('project_domain_name'):
                 kc_args['project_domain_name'] = kwargs.get('domain_name')
-            if kwargs.get('domain_id'):
+            if kwargs.get('project_domain_id'):
                 kc_args['project_domain_id'] = kwargs.get('domain_id')
 
         if kwargs.get('token'):
@@ -55,8 +60,11 @@ class KSClient(object):
         else:
             kc_args['username'] = kwargs.get('username')
             kc_args['password'] = kwargs.get('password')
+            kc_args['user_domain_name'] = kwargs.get('user_domain_name')
+            kc_args['user_domain_id'] = kwargs.get('user_domain_id')
 
         self._kwargs = kwargs
+        log.debug("Creating keystone client: {0}".format(repr(kc_args)))
         self._keystone = client.Client(**kc_args)
         self._token = None
         self._monasca_url = None

--- a/monascaclient/ksclient.py
+++ b/monascaclient/ksclient.py
@@ -18,13 +18,9 @@ Wrapper around python keystone client to assist in getting a properly scoped tok
 endpoint for Monasca.
 """
 
-import logging
-
 from keystoneclient.v3 import client
 
 from monascaclient import exc
-
-log = logging.getLogger(__name__)
 
 class KSClient(object):
     def __init__(self, **kwargs):
@@ -33,8 +29,8 @@ class KSClient(object):
         :param username: name of user
         :param password: user's password
         :param user_domain_id: unique identifier of domain username resides in (optional)
-	:param user_domain_name: name of domain for username
-	:param project_id: unique identifier of project
+        :param user_domain_name: name of domain for username
+        :param project_id: unique identifier of project
         :param project_name: name of project
         :param domain_name: name of domain project is in
         :param domain_id: id of domain project is in
@@ -50,9 +46,9 @@ class KSClient(object):
             kc_args['project_id'] = kwargs.get('project_id')
         elif kwargs.get('project_name'):
             kc_args['project_name'] = kwargs.get('project_name')
-            if kwargs.get('project_domain_name'):
+            if kwargs.get('domain_name'):
                 kc_args['project_domain_name'] = kwargs.get('domain_name')
-            if kwargs.get('project_domain_id'):
+            if kwargs.get('domain_id'):
                 kc_args['project_domain_id'] = kwargs.get('domain_id')
 
         if kwargs.get('token'):

--- a/monascaclient/ksclient.py
+++ b/monascaclient/ksclient.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2014 Hewlett-Packard Development Company, L.P.i
+# Copyright (c) 2014 Hewlett-Packard Development Company, L.P.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -64,7 +64,6 @@ class KSClient(object):
             kc_args['user_domain_id'] = kwargs.get('user_domain_id')
 
         self._kwargs = kwargs
-        log.debug("Creating keystone client: {0}".format(repr(kc_args)))
         self._keystone = client.Client(**kc_args)
         self._token = None
         self._monasca_url = None


### PR DESCRIPTION
Added configuration parameters for specifying the domain of a user and ensured that these parameters reach the Keystone API. 

Fix for https://bugs.launchpad.net/monasca/+bug/1471882